### PR TITLE
use local generated uids

### DIFF
--- a/conf/mail2most.conf
+++ b/conf/mail2most.conf
@@ -117,6 +117,9 @@
   ReadOnly = true
   # ImapTLS allows you to enable / disable tls encryption whithin the imap protocol
   ImapTLS = true
+  # GenerateLocalUIDs creates a uid from message data instead of fetching the uid from the server 
+  # this can be helpfull when getting Invalid messageset errors since some DoveCot mailserver died not implement IMAP correctly
+  GenerateLocalUIDs = false
 
   #[Profile.Mattermost] contains the mattermost configuration and overwrites the default
   [Profile.Mattermost]

--- a/conf/mail2most.conf
+++ b/conf/mail2most.conf
@@ -39,8 +39,11 @@
     ImapTLS = true
     # VerifyTLS disables certificate validation (only disable for self-signed certs)
     VerifyTLS = true
-    # limit allows you to limit the amount of emails read from the mail server, if set to 0 its unlimited
+    # Limit allows you to limit the amount of emails read from the mail server, if set to 0 its unlimited
     Limit = 0
+    # GenerateLocalUIDs creates a uid from message data instead of fetching the uid from the server 
+    # this can be helpfull when getting Invalid messageset errors since some DoveCot mailserver died not implement IMAP correctly
+    GenerateLocalUIDs = false
 
   # The DefaultProfile.Mattermost defines a default mattermost server
   # if your Profile has no defined mattermost server this information will be used

--- a/conf/mail2most.conf
+++ b/conf/mail2most.conf
@@ -42,7 +42,7 @@
     # Limit allows you to limit the amount of emails read from the mail server, if set to 0 its unlimited
     Limit = 0
     # GenerateLocalUIDs creates a uid from message data instead of fetching the uid from the server 
-    # this can be helpfull when getting Invalid messageset errors since some DoveCot mailserver died not implement IMAP correctly
+    # this can be helpfull when getting Invalid messageset errors since some DoveCot mailserver did not implement IMAP correctly
     GenerateLocalUIDs = false
 
   # The DefaultProfile.Mattermost defines a default mattermost server

--- a/conf/testing.conf
+++ b/conf/testing.conf
@@ -30,6 +30,9 @@
   ReadOnly = true
   # ImapTLS allows you to enable / disable tls encryption whithin the imap protocol
   ImapTLS = true
+  # GenerateLocalUIDs creates a uid from message data instead of fetching the uid from the server
+  # this can be helpfull when getting Invalid messageset errors since some DoveCot mailserver died not implement IMAP correctly
+  GenerateLocalUIDs = false
 
   #[Profile.Mattermost] contains the mattermost configuration
   [Profile.Mattermost]

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.uber.org/zap v1.15.0 // indirect
-	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
+	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
 	golang.org/x/text v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -536,6 +536,8 @@ golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 h1:DZhuSZLsGlFL4CmhA8BcRA0mnthyA/nZ00AqCUo7vHg=
 golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/lib/config.go
+++ b/lib/config.go
@@ -38,6 +38,7 @@ type maildata struct {
 	ImapTLS                        bool
 	VerifyTLS                      bool
 	Limit                          uint32
+	GenerateLocalUIDs              bool
 }
 
 type filter struct {

--- a/lib/imap.go
+++ b/lib/imap.go
@@ -2,6 +2,7 @@ package mail2most
 
 import (
 	"crypto/tls"
+	"hash/fnv"
 	"strings"
 
 	imap "github.com/emersion/go-imap"
@@ -120,10 +121,20 @@ func (m Mail2Most) GetMail(profile int) ([]Mail, error) {
 		messages := make(chan *imap.Message, 10000)
 		done := make(chan error, 1)
 		go func() {
-			done <- c.Fetch(seqset, []imap.FetchItem{imap.FetchEnvelope, "BODY[]", imap.FetchUid}, messages)
+			fetchMessage := imap.FetchUid
+			if m.Config.Profiles[profile].Mail.GenerateLocalUIDs {
+				fetchMessage = imap.FetchRFC822
+			}
+			done <- c.Fetch(seqset, []imap.FetchItem{imap.FetchEnvelope, "BODY[]", fetchMessage}, messages)
 		}()
 
 		for msg := range messages {
+			if m.Config.Profiles[profile].Mail.GenerateLocalUIDs {
+				h := fnv.New32a()
+				h.Reset()
+				h.Write([]byte(msg.Envelope.MessageId))
+				msg.Uid = h.Sum32()
+			}
 			m.Debug("processing message", map[string]interface{}{"uid": msg.Uid, "subject": msg.Envelope.Subject})
 			r := msg.GetBody(&imap.BodySectionName{})
 

--- a/lib/imap.go
+++ b/lib/imap.go
@@ -133,6 +133,8 @@ func (m Mail2Most) GetMail(profile int) ([]Mail, error) {
 			if m.Config.Profiles[profile].Mail.GenerateLocalUIDs {
 				h := fnv.New32a()
 				h.Reset()
+				// since we make this profile specific changing the profile order will break this
+				// but using the profile will prevent having dublicated uid between profiles with the same mailbox
 				h.Write([]byte(msg.Envelope.MessageId + "/profile/" + strconv.Itoa(profile)))
 				msg.Uid = h.Sum32()
 			}

--- a/lib/imap.go
+++ b/lib/imap.go
@@ -3,6 +3,7 @@ package mail2most
 import (
 	"crypto/tls"
 	"hash/fnv"
+	"strconv"
 	"strings"
 
 	imap "github.com/emersion/go-imap"
@@ -132,7 +133,7 @@ func (m Mail2Most) GetMail(profile int) ([]Mail, error) {
 			if m.Config.Profiles[profile].Mail.GenerateLocalUIDs {
 				h := fnv.New32a()
 				h.Reset()
-				h.Write([]byte(msg.Envelope.MessageId))
+				h.Write([]byte(msg.Envelope.MessageId + "/profile/" + strconv.Itoa(profile)))
 				msg.Uid = h.Sum32()
 			}
 			m.Debug("processing message", map[string]interface{}{"uid": msg.Uid, "subject": msg.Envelope.Subject})


### PR DESCRIPTION
#50 - due to some doveCot servers not correctly implementing IMAP, `goimap.FetchUID` can not be used. Instead hash32 over `msg.Envelope.MessageID` is used to create a int32 uid.

##### Checklist

- [x] `mage test` passes
- [x] unit tests are included and tested
- [x] documentation is added or changed
