### PR TITLE
issue #64 config option to allow/deny processing of empty messages

### DIFF
--- a/conf/mail2most.conf
+++ b/conf/mail2most.conf
@@ -68,6 +68,8 @@
     SubjectOnly = false
     # BodyOnly will post only the mail body
     BodyOnly = false
+    # SkipEmptyMessages - only post messages with non empty email bodys
+    SkipEmptyMessages = false
     # StripHTML will remove all HTML tags bevor sending a msg to mattermost
     StripHTML = true
     # ConvertToMarkdown will convert html mails to markdown for better readability in mattermost

--- a/lib/config.go
+++ b/lib/config.go
@@ -56,6 +56,7 @@ type mattermost struct {
 	Broadcast                                  []string
 	SubjectOnly                                bool
 	BodyOnly                                   bool
+	SkipEmptyMessages                          bool
 	StripHTML                                  bool
 	ConvertToMarkdown                          bool
 	HideFrom                                   bool

--- a/lib/imap.go
+++ b/lib/imap.go
@@ -176,14 +176,6 @@ func (m Mail2Most) GetMail(profile int) ([]Mail, error) {
 				return []Mail{}, err
 			}
 
-			// Skip empty messages.
-			if len(strings.TrimSpace(body)) < 1 && len(attachments) < 1 {
-				m.Info("blank message", map[string]interface{}{
-					"subject": msg.Envelope.Subject, "uid": msg.Uid,
-				})
-				continue
-			}
-
 			// Skip mailserver error notifications.
 			if strings.HasPrefix(msg.Envelope.Subject, "Delivery Status Notification") {
 				if m.Config.Profiles[profile].Filter.IgnoreMailErrorNotifications {

--- a/lib/mattermost.go
+++ b/lib/mattermost.go
@@ -87,8 +87,10 @@ func (m Mail2Most) PostMattermost(profile int, mail Mail) error {
 	}
 
 	if len(strings.TrimSpace(body)) < 1 {
-		m.Info("dead body found", map[string]interface{}{"function": "Mail2Most.PostMattermost"})
-		return nil
+		if m.Config.Profiles[profile].Mattermost.SkipEmptyMessages {
+			m.Info("empty message body found", map[string]interface{}{"function": "Mail2Most.PostMattermost"})
+			return nil
+		}
 	}
 
 	if m.Config.Profiles[profile].Mattermost.BodyPrefix != "" {


### PR DESCRIPTION
Additional config option for processing empty message bodys (issue #64)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `mage test` passes
- [x] unit tests are included and tested
- [x] documentation is added or changed
